### PR TITLE
Update Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 updates:
-  # Python dependencies (uv)
-  - package-ecosystem: "pip"
+  # Python dependencies (using uv package manager)
+  # Dependabot will update both pyproject.toml and uv.lock
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Update Dependabot configuration to target uv projects instead of pip. This will enable Dependabot to properly update both pyproject.toml and uv.lock files.