### PR TITLE
fix(cli): improve agent --check display and logging

### DIFF
--- a/src/agent/cli/app.py
+++ b/src/agent/cli/app.py
@@ -380,11 +380,11 @@ def run_health_check() -> None:
                     logger.debug(f"Failed to fetch Docker models: {e}")
                     # Silently continue - DMR might not be enabled
             else:
-                console.print(f"  [yellow]◉[/yellow] Not running")
+                console.print("  [yellow]◉[/yellow] Not running")
         except FileNotFoundError:
-            console.print(f"  [dim]○[/dim] Not installed")
+            console.print("  [dim]○[/dim] Not installed")
         except subprocess.TimeoutExpired:
-            console.print(f"  [yellow]◉[/yellow] Timeout (check if running)")
+            console.print("  [yellow]◉[/yellow] Timeout (check if running)")
 
         # LLM Providers - Test all with connectivity
         console.print("\n[bold]LLM Providers:[/bold]")


### PR DESCRIPTION
## Summary
Fixes display issues with `agent --check` command for better user experience in Windows terminals.

## Changes

### 1. Suppress middleware ERROR logs during connectivity tests
- **Problem**: When testing provider connectivity, middleware was logging ERROR messages even though the visual indicators correctly showed failures
- **Solution**: Temporarily set middleware logger to CRITICAL level during connectivity tests, restore after completion
- **Impact**: Clean output when running `agent --check` - only visual indicators shown, no ERROR log spam

### 2. Disable Rich auto-highlighting for version numbers
- **Problem**: Rich was applying syntax highlighting to version numbers (e.g., 3.12.10), causing numbers to display in different colors than letters
- **Solution**: Added `highlight=False` to Python version and Platform lines
- **Impact**: Uniform cyan color throughout the version and platform strings

### 3. Document intentional Unicode character usage
- Added docstring and inline comments explaining that Unicode characters (◉, ○, ✓, ⚠) are intentional
- Documented that these render correctly in modern terminals but may fail when piped through non-interactive shells
- Justifies the trade-off: interactive display quality over piped output compatibility

## Testing
- ✅ Tested in PowerShell - clean output with no ERROR logs
- ✅ Unicode characters display correctly
- ✅ Colors are uniform (cyan for values, magenta for agent settings)
- ✅ Exit codes work correctly (0 = success, 1 = failure)

## Test Plan
```bash
# Test with no providers configured
agent --check

# Should show clean output like:
System:
  ◉ Python 3.12.10
  ◉ Platform: Windows-11-10.0.26200-SP0
  ◉ Data: C:\Users\user\.agent

Agent:
  ◉ Log Level: INFO
  ◉ System Prompt: Default

Docker:
  ◉ Running (28.5.1) · 8 cores, 15.5 GiB

LLM Providers:
✓ ◉ Local (ai/phi4) - Connection failed
  ○ OpenAI - Not configured
  ...

⚠ Active provider (local) is not connected
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>