### PR TITLE
Fix printing functionality issue

### DIFF
--- a/src/agent/cli/app.py
+++ b/src/agent/cli/app.py
@@ -105,7 +105,7 @@ def main(
     prompt: str = typer.Option(None, "-p", "--prompt", help="Execute a single prompt and exit"),
     check: bool = typer.Option(False, "--check", help="Show configuration and connectivity status"),
     config_flag: bool = typer.Option(
-        False, "--config", help="Show configuration and connectivity status (alias for --check)"
+        False, "--config", help="Show configuration and connectivity status"
     ),
     version_flag: bool = typer.Option(False, "--version", help="Show version"),
     telemetry: str = typer.Option(

--- a/tests/validation/test_agent_validation.py
+++ b/tests/validation/test_agent_validation.py
@@ -345,7 +345,7 @@ class TestAgentValidation:
         assert has_sections or has_config_error, "Should show health check or config error"
 
     def test_config_command(self, validator):
-        """Test config command (alias for --check)."""
+        """Test config command."""
         # Longer timeout needed when running in parallel (connectivity tests to multiple providers)
         result = validator.run_command("uv run agent --config", timeout=60)
         # Strip ANSI codes to focus on content not formatting


### PR DESCRIPTION
Remove "(alias for --check)" from the --config option help text to clean up the CLI help output.