### PR TITLE
ci: enable CodeQL and CI on release-please branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release-please--**'
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,7 +2,9 @@ name: Security Scanning
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - 'release-please--**'
   pull_request:
     branches: [ main ]
   schedule:


### PR DESCRIPTION
- Concise summary of changes:
  - Expanded GitHub Actions workflow triggers to include release-please generated branches in both CI and security scanning workflows, in addition to the main branch.

- Key modifications and their purpose:
  - ci.yml: Change push triggers from only main to include main and release-please pattern
    - Purpose: Ensure CI runs on release-please PR/branch updates as part of automated release flow.
  - security.yml: Change push triggers from only main to include main and release-please pattern
    - Purpose: Ensure security scanning runs for release-please generated branches and PRs, not just main.

- Notable technical details:
  - Branch pattern used: 'release-please--**'
    - Provides wildcard matching for branches created by the release-please tool.
  - Both workflows now apply similar broadened triggers on push events, aligning coverage with PR workflows.

- Security impact analysis:
  - Affected workflow behavior:
    - Previously, security scans triggered only on pushes to main; now they also trigger on pushes to release-please generated branches.
  - Potential impact:
    - Positive: Security scanning will detect vulnerabilities in code changes introduced by release-please-generated branches earlier in the release process.
  - No vulnerabilities introduced or fixed by this change itself; this change only broadens trigger coverage to improve vulnerability detection on release-related branches.

- Last specific change:
  - Include branch pattern 'release-please--**' in both workflows.